### PR TITLE
Update modal to match dark theme styles

### DIFF
--- a/darkMode.css
+++ b/darkMode.css
@@ -46,3 +46,13 @@ p, ol, li, a:hover, .far {
 progress-circle__image, progress-circle__inner {
   background-color: var(--dark-bg-accent) !important;
 }
+
+.react-modal__body, .react-modal__body h1 {
+  background-color: var(--dark-bg-color) !important;
+  color: var(--dark-font-color) !important;
+}
+
+.react-modal__body .form__element {
+  background-color: var(--dark-bg-accent) !important;
+  color: var(--dark-font-color) !important;
+}


### PR DESCRIPTION
After submitting a project I noticed the modal that pops up for project submission doesn't match the dark theme styles and some text is unreadable with the dark mode add-on enabled.

This PR will fix that issue by applying the dark mode styles to the modal in question.

## before
![image](https://user-images.githubusercontent.com/7115053/123843513-f97da600-d8df-11eb-9f7a-be282b4a44c6.png)

![image](https://user-images.githubusercontent.com/7115053/123843556-08fcef00-d8e0-11eb-8db2-1b927fb5d871.png)

![image](https://user-images.githubusercontent.com/7115053/123843435-e539a900-d8df-11eb-9799-f241f7877ed1.png)

## after
![image](https://user-images.githubusercontent.com/7115053/123843695-2fbb2580-d8e0-11eb-93b8-2eaa14aaf036.png)

![image](https://user-images.githubusercontent.com/7115053/123843757-3e094180-d8e0-11eb-9a30-4c3b79fcec78.png)

![image](https://user-images.githubusercontent.com/7115053/123843779-4497b900-d8e0-11eb-80fb-8ab41d94f00c.png)
